### PR TITLE
修复一些bug

### DIFF
--- a/NEWorld.vcxproj
+++ b/NEWorld.vcxproj
@@ -64,17 +64,17 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>$(SolutionDir)include\AL;$(ProjectDir)include;$(ProjectDir)include\asio;$(IncludePath)</IncludePath>
-    <LibraryPath>$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(ProjectDir)lib\Debug;$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IncludePath>$(SolutionDir)include\AL;$(ProjectDir)include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(ProjectDir)lib\Release;$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile|Win32'">
     <IncludePath>$(SolutionDir)include\AL;$(ProjectDir)include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
+    <LibraryPath>$(ProjectDir)lib\Debug;$(ProjectDir)lib;$(ProjectDir)$(Configuration);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -95,7 +95,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;OpenAL32.lib;EFX-Util.lib;libogg_static.lib;libvorbis_static.lib;libvorbisfile_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;audiolibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Profile>false</Profile>
       <SubSystem>Console</SubSystem>
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
@@ -135,7 +135,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;OpenAL32.lib;EFX-Util.lib;libogg_static.lib;libvorbis_static.lib;libvorbisfile_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;audiolibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -168,7 +168,7 @@
       <GenerateDebugInformation>Debug</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;OpenAL32.lib;EFX-Util.lib;libogg_static.lib;libvorbis_static.lib;libvorbisfile_static.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>PluginSDK.lib;opengl32.lib;glfw3dll.lib;ws2_32.lib;freetype2.lib;audiolibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
       <AssemblyDebug>true</AssemblyDebug>
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
@@ -217,11 +217,6 @@
     <ClInclude Include="source\WorldRenderer.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="include\AL\AL-EFX.cpp" />
-    <ClCompile Include="include\AL\ALDevice.cpp" />
-    <ClCompile Include="include\AL\aldlist.cpp" />
-    <ClCompile Include="include\AL\CWaves.cpp" />
-    <ClCompile Include="include\AL\Framework.cpp" />
     <ClCompile Include="source\AudioSystem.cpp" />
     <ClCompile Include="source\BlockFuncs.cpp" />
     <ClCompile Include="source\Chunk.cpp" />

--- a/NEWorld.vcxproj.filters
+++ b/NEWorld.vcxproj.filters
@@ -281,18 +281,6 @@
     <ClCompile Include="source\GameView.cpp">
       <Filter>Source\Game</Filter>
     </ClCompile>
-    <ClCompile Include="include\AL\ALDevice.cpp">
-      <Filter>Source\Common\OpenAL</Filter>
-    </ClCompile>
-    <ClCompile Include="include\AL\aldlist.cpp">
-      <Filter>Source\Common\OpenAL</Filter>
-    </ClCompile>
-    <ClCompile Include="include\AL\AL-EFX.cpp">
-      <Filter>Source\Common\OpenAL</Filter>
-    </ClCompile>
-    <ClCompile Include="include\AL\CWaves.cpp">
-      <Filter>Source\Common\OpenAL</Filter>
-    </ClCompile>
     <ClCompile Include="source\AudioSystem.cpp">
       <Filter>Source\Game</Filter>
     </ClCompile>
@@ -304,9 +292,6 @@
     </ClCompile>
     <ClCompile Include="source\RandGen.cpp">
       <Filter>Source\Common\RandGen</Filter>
-    </ClCompile>
-    <ClCompile Include="include\AL\Framework.cpp">
-      <Filter>Source\Common\OpenAL</Filter>
     </ClCompile>
     <ClCompile Include="source\logger.cpp">
       <Filter>Source\Common</Filter>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NEWorld
+﻿# NEWorld
 
 全新的NEWorld!
 
@@ -8,7 +8,7 @@ NEWorld采用[GPLv3许可证](http://www.gnu.org/licenses/gpl.html)发布并受�
 
 ## 资源文件
 
-* [libraries](http://pan.baidu.com/s/1jHz7rAe)
+* [libraries](http://pan.baidu.com/s/1bo3wOnd)
 
 ## 更多文档
 

--- a/SIGNOFF
+++ b/SIGNOFF
@@ -1,4 +1,4 @@
-在此文件中署名的所有开发者承诺：
+﻿在此文件中署名的所有开发者承诺：
 我愿将所有对NEWorld作出的贡献以GPLv3许可证发布。
 
 The undersigned release all their contributions to the NEWorld project under the GPLv3 license.
@@ -6,3 +6,5 @@ The undersigned release all their contributions to the NEWorld project under the
 D Laboratory <dlaboratory@126.com> aka <dlaboratory@outlook.com>
 
 ascchrvalstr <zgnjycxxdyt@sina.com> aka <zgnjycxxdyt@163.com>, <zgnjycxxdyt@126.com>, <zgnjycxxdyt@yeah.net>, <ascchrvalstr@hotmail.com>, <zgnjycxxdyt@qq.com>, <zgnjycxxdyt@foxmail.com>, <ascchrvalstr@gmail.com>
+
+dtcxzyw <2601110573@qq.com>

--- a/source/Chunk.cpp
+++ b/source/Chunk.cpp
@@ -187,7 +187,7 @@ void chunk::Load(bool initIfEmpty)
         {
             //Build trees
             for (size_t index = 0; index < 4096; index++)
-                if (pblocks[index] == block(Blocks::GRASS) && pRandGen->one_in(200))
+                if (pblocks[index] == block(Blocks::GRASS) && ((cx&cy^cz|~index)%233)==0)
                     buildtree((cx << 4) ^ ((index&((1 << 12) - (1 << 8))) >> 8), (cy << 4) ^ ((index&((1 << 8) - (1 << 4))) >> 4), (cz << 4) ^ (index & 15));
         }
     }

--- a/source/Network.h
+++ b/source/Network.h
@@ -23,12 +23,12 @@
 #define ASIO_STANDALONE
 
 #ifdef NEWORLD_TARGET_WINDOWS
-#include <asio/asio.hpp>
+#include <boost/asio.hpp>
 #elif NEWORLD_TARGET_MACOSX
 #include <asio.hpp>
 #endif
 
-using namespace asio;
+using namespace boost::asio;
 
 namespace Network
 {

--- a/source/World.cpp
+++ b/source/World.cpp
@@ -1000,16 +1000,12 @@ bool buildtree(int x, int y, int z)
 {
     int i, ix, iy, iz;
     //对生成条件进行更严格的检测
-    //正上方五格必须为空气
-    for (i = y + 1; i < y + 6; i++)
+    //正上方七格必须为空气
+    for (i = y + 1; i < y + 8; i++)
     {
         if (getblock(x, i, z) != block(Blocks::AIR))
             return false;
     }
-    //开始生成
-    //设置泥土
-    setblock(x, y, z, block(Blocks::DIRT));
-    //设置树干
     int h = 0, dirt = 0;//泥土数
     for (ix = x - 4; ix < x + 4; ix++)
     {
@@ -1028,7 +1024,10 @@ bool buildtree(int x, int y, int z)
     h = static_cast<int>( min( (double)h, dirt * 15 / 268 * max(pRandGen->get_double_co(), 0.8) ) );
     if (h < 7)
         return false;
+    //开始生成
 
+    //设置泥土
+    setblock(x, y, z, block(Blocks::DIRT));
     //使用lambda表达式递归模拟树生长
     int begin = y + h * 0.618;
     Vector3D middle(x, y + h, z);


### PR DESCRIPTION
1.修复树生成器的bug;
2.修复audio链接库的bug(但glfw与freetype仍然使用静态链接，原因是没有提供动态链接的配置)，链接库地址已更换,
其中AL的二次封装已经被编译进库里，保留源文件是为了留给MAC上编译用。
