### PR TITLE
use unordered_map as CommandMap instead of map

### DIFF
--- a/src/shared/command.h
+++ b/src/shared/command.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 #include <functional>
-#include <map>
+#include <unordered_map>
 
 class CommandExecuteStat
 {
@@ -68,6 +68,6 @@ public:
 };
 
 using CommandHandleFunction = std::function<CommandExecuteStat(Command)>;
-using CommandMap = std::map<std::string, std::pair<CommandInfo, CommandHandleFunction>>;
+using CommandMap = std::unordered_map<std::string, std::pair<CommandInfo, CommandHandleFunction>>;
 
 #endif // !COMMAND_H_


### PR DESCRIPTION
`std::unordered_map`是hash表，效率比`std::map`高到不知道哪里去
`std::map`的唯一优势是ordered，在任何不需要顺序查找的case都应该使用`std::unordered_map`而不是`std::map`
